### PR TITLE
Restore container insertion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # WidgetRelation
-# WidgetRelation
-# WidgetRelation
-# WidgetRelation
-# WidgetRelation
+
+A small TypeScript playground that demonstrates building widget trees with horizontal and vertical containers. Widgets can be aligned within their parent container and rendered to the DOM.
+
+## Development
+
+```bash
+npm run dev
+```
+
+The demo page will open in the browser via webpack-dev-server.

--- a/src/tasks/classes/ContainerWidget.ts
+++ b/src/tasks/classes/ContainerWidget.ts
@@ -2,16 +2,18 @@ import { Align } from "../enums";
 import Widget from "./Widget";
 
 export default abstract class ContainerWidget extends Widget {
-    private children: Widget[];
+  private children: Widget[];
 
-    constructor(align: Align = Align.alClient, displayable: boolean = true, children: Widget[] = []) {
-        super(align, displayable);
-        this.children = children;
-    }
+  constructor(
+    align: Align = Align.alClient,
+    displayable: boolean = true,
+    children: Widget[] = [],
+  ) {
+    super(align, displayable);
+    this.children = children;
+  }
 
-    public getChildren() {
-        return this.children;
-    }
-
-    // public abstract sortChildren(): Widget[];
+  public getChildren() {
+    return this.children;
+  }
 }

--- a/src/tasks/classes/HBoxContainer.ts
+++ b/src/tasks/classes/HBoxContainer.ts
@@ -3,47 +3,44 @@ import CssClasses from "../enums/CssClasses";
 import ContainerWidget from "./ContainerWidget";
 
 export default class HBoxContainer extends ContainerWidget {
+  public createDOM = (): HTMLDivElement => {
+    const el = document.createElement("div");
+    el.classList.add(CssClasses.CONTAINER);
+    el.classList.add(CssClasses.CONTAINER_H);
+    el.classList.add(this.getAlign());
 
-    public createDOM = (): HTMLDivElement => {
-        const el = document.createElement('div');
-        el.classList.add(CssClasses.CONTAINER);
-        el.classList.add(CssClasses.CONTAINER_H);
-        el.classList.add(this.getAlign());
-        this.getChildren().forEach(i => {
-            switch (i.getAlign()) {
-                case Align.alLeft:
-                    if (el.firstChild) {
-                        el.insertBefore(i.createDOM(), el.firstChild);
-                    } else {
-                        el.appendChild(i.createDOM());
-                    }
-                    break;
-                case Align.alClient:
-                    let firstRightChild: HTMLElement | null = null;
-
-                    for (let i = 0; i < el.childNodes.length; i++) {
-                        const child = el.childNodes.item(i);
-                        if (!(child instanceof HTMLElement)) throw new Error("Invalid Type");
-                        if (child.classList.contains(Align.alRight)) {
-                            firstRightChild = child;
-                            break;
-                        }
-                    }
-
-                    if (firstRightChild) {
-                        el.insertBefore(i.createDOM(), firstRightChild);
-                    } else {
-                        el.appendChild(i.createDOM());
-                    }
-
-                    break;
-                case Align.alRight:
-                    el.appendChild(i.createDOM());
-                    break;
-                default: throw new Error("Unexpected case");
+    for (const child of this.getChildren()) {
+      switch (child.getAlign()) {
+        case Align.alLeft:
+          if (el.firstChild) {
+            el.insertBefore(child.createDOM(), el.firstChild);
+          } else {
+            el.appendChild(child.createDOM());
+          }
+          break;
+        case Align.alClient: {
+          let firstRight: HTMLElement | null = null;
+          for (const node of Array.from(el.children)) {
+            if (node.classList.contains(Align.alRight)) {
+              firstRight = node as HTMLElement;
+              break;
             }
-        });
-        return el;
+          }
+          if (firstRight) {
+            el.insertBefore(child.createDOM(), firstRight);
+          } else {
+            el.appendChild(child.createDOM());
+          }
+          break;
+        }
+        case Align.alRight:
+          el.appendChild(child.createDOM());
+          break;
+        default:
+          throw new Error("Unexpected align");
+      }
     }
 
+    return el;
+  };
 }

--- a/src/tasks/classes/VBoxContainer.ts
+++ b/src/tasks/classes/VBoxContainer.ts
@@ -3,71 +3,44 @@ import CssClasses from "../enums/CssClasses";
 import ContainerWidget from "./ContainerWidget";
 
 export default class VBoxContainer extends ContainerWidget {
+  public createDOM = (): HTMLDivElement => {
+    const el = document.createElement("div");
+    el.classList.add(CssClasses.CONTAINER);
+    el.classList.add(CssClasses.CONTAINER_V);
+    el.classList.add(this.getAlign());
 
-    // public sortChildren(): Widget[] {
-    //     const topChildren: Widget[] = [];
-    //     const centerChildren: Widget[] = [];
-    //     const bottomChildren: Widget[] = [];
-
-    //     this.getChildren().forEach(i => {
-    //         switch (i.getAlign()) {
-    //             case Align.alTop:
-    //                 topChildren.push(i);
-    //                 break;
-    //             case Align.alClient:
-    //                 centerChildren.push(i);
-    //                 break;
-    //             case Align.alBottom:
-    //                 bottomChildren.push(i);
-    //                 break;
-    //             default: throw new Error("Unexpected case");
-    //         }
-    //     });
-
-    //     return [...topChildren, ...centerChildren, ...bottomChildren];
-    // }
-
-    public createDOM = (): HTMLDivElement => {
-        const el = document.createElement('div');
-        el.classList.add(CssClasses.CONTAINER);
-        el.classList.add(CssClasses.CONTAINER_V);
-        el.classList.add(this.getAlign());
-        this.getChildren().forEach(i => {
-            switch (i.getAlign()) {
-                case Align.alTop:
-                    if (el.firstChild) {
-                        el.insertBefore(i.createDOM(), el.firstChild);
-                    } else {
-                        el.appendChild(i.createDOM());
-                    }
-                    break;
-                case Align.alClient:
-                    let firstBottomChild: HTMLElement | null = null;
-
-                    for (let i = 0; i < el.childNodes.length; i++) {
-                        const child = el.childNodes.item(i);
-                        if (!(child instanceof HTMLElement)) throw new Error("Invalid Type");
-                        if (child.classList.contains(Align.alBottom)) {
-                            console.log(firstBottomChild)
-                            firstBottomChild = child;
-                            break;
-                        }
-                    }
-
-                    if (firstBottomChild) {
-                        el.insertBefore(i.createDOM(), firstBottomChild);
-                    } else {
-                        el.appendChild(i.createDOM());
-                    }
-
-                    break;
-                case Align.alBottom:
-                    el.appendChild(i.createDOM());
-                    break;
-                default: throw new Error("Unexpected case");
+    for (const child of this.getChildren()) {
+      switch (child.getAlign()) {
+        case Align.alTop:
+          if (el.firstChild) {
+            el.insertBefore(child.createDOM(), el.firstChild);
+          } else {
+            el.appendChild(child.createDOM());
+          }
+          break;
+        case Align.alClient: {
+          let firstBottom: HTMLElement | null = null;
+          for (const node of Array.from(el.children)) {
+            if (node.classList.contains(Align.alBottom)) {
+              firstBottom = node as HTMLElement;
+              break;
             }
-        });
-        return el;
+          }
+          if (firstBottom) {
+            el.insertBefore(child.createDOM(), firstBottom);
+          } else {
+            el.appendChild(child.createDOM());
+          }
+          break;
+        }
+        case Align.alBottom:
+          el.appendChild(child.createDOM());
+          break;
+        default:
+          throw new Error("Unexpected align");
+      }
     }
 
+    return el;
+  };
 }

--- a/src/tasks/classes/Widget.ts
+++ b/src/tasks/classes/Widget.ts
@@ -2,32 +2,35 @@ import { Align } from "../enums";
 import CssClasses from "../enums/CssClasses";
 
 export default class Widget {
-    private static INDEX: number = 0;
-    private align: Align;
-    private displayable: boolean;
+  private static INDEX: number = 0;
+  private align: Align;
+  private displayable: boolean;
 
-    constructor(align: Align = Align.alClient, displayable: boolean = true) {
-        this.align = align;
-        this.displayable = displayable;
-    }
+  constructor(align: Align = Align.alClient, displayable: boolean = true) {
+    this.align = align;
+    this.displayable = displayable;
+  }
 
-    public isDisplayable(): boolean {
-        return this.displayable;
-    }
+  public isDisplayable(): boolean {
+    return this.displayable;
+  }
 
-    public getAlign() {
-        return this.align;
-    }
+  public getAlign() {
+    return this.align;
+  }
 
-    public setAlign(align: Align) {
-        this.align = align;
-    }
+  public setAlign(align: Align) {
+    this.align = align;
+  }
 
-    public createDOM = (): HTMLDivElement => {
-        const el = document.createElement('div');
-        el.classList.add(CssClasses.WIDGET);
-        el.classList.add(this.getAlign());
-        el.innerText = `id: ${++Widget.INDEX}; al: ${this.getAlign()}`;
-        return el;
+  public createDOM = (): HTMLDivElement => {
+    const el = document.createElement("div");
+    el.classList.add(CssClasses.WIDGET);
+    el.classList.add(this.getAlign());
+    if (!this.displayable) {
+      el.classList.add(CssClasses.DISABLED);
     }
+    el.innerText = `id: ${++Widget.INDEX}; al: ${this.getAlign()}`;
+    return el;
+  };
 }


### PR DESCRIPTION
## Summary
- remove unused `sortChildren`
- keep container DOM assembly that inserts children dynamically
- keep disabled widget class logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8b097508321905be34c8d61298f